### PR TITLE
Tighten up language around source-only libraries.

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -62,9 +62,9 @@ Library routines may allocate memory internally, but not in a way that affects t
 Exceptions are inefficient and use the GC. Of course, they cannot be used in `nothrow` code. Examine each use of an Exception to see if it can be designed out of existence, like the Replacement Character method above. Design the return value such that an error is not necessary - for example, a string search function can return an empty string if not found rather than throw an Exception.
 Investigate the use of Option types for error returns.
 
-### Header Only
+### Source Only
 
-By making the library header only, it becomes inured against variations in compiler flags. Whether it's a static or dynamic library becomes irrelevant, and there won't be impedance mismatches.
+Currently, Phobos is distributed as a separately compiled library with "header" files that contain on the necessary Template implementations. The net result is that Phobos is primarily a source-only library in practice. By formalizing the library as a source only library, it becomes inured against variations in compiler flags. Whether it's a static or dynamic library becomes irrelevant, and there won't be impedance mismatches. DRuntime will remain a separately compiled library.
 
 ## Specific Issues
 

--- a/Design.md
+++ b/Design.md
@@ -64,7 +64,7 @@ Investigate the use of Option types for error returns.
 
 ### Source Only
 
-Currently, Phobos is distributed as a separately compiled library with "header" files that contain on the necessary Template implementations. The net result is that Phobos is primarily a source-only library in practice. By formalizing the library as a source only library, it becomes inured against variations in compiler flags. Whether it's a static or dynamic library becomes irrelevant, and there won't be impedance mismatches. DRuntime will remain a separately compiled library.
+Currently, Phobos is distributed as a separately compiled library with "header" files that contain only the necessary Template implementations. The net result is that Phobos is primarily a source-only library in practice. By formalizing the library as a source only library, it becomes inured against variations in compiler flags. Whether it's a static or dynamic library becomes irrelevant, and there won't be impedance mismatches. DRuntime will remain a separately compiled library.
 
 ## Specific Issues
 


### PR DESCRIPTION
@WalterBright This just cleans up the language around "Header Only". "Source-Only" is probably less confusing.